### PR TITLE
feat(release command): release command now skips husky git hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "prettier": "prettier --write ./src/**/*.js",
-    "release": "standard-version",
+    "release": "HUSKY_SKIP_HOOKS=1 standard-version",
     "start": "node .",
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
add `HUSKY_SKIP_HOOKS=1 standard-version` to release without running the prepare-commit-msg hook (as well as other hooks)